### PR TITLE
Added a console and ImGui Logging window

### DIFF
--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -524,6 +524,7 @@
     <ClInclude Include="src\PhysicsObject.h" />
     <ClInclude Include="src\Sprite.h" />
     <ClInclude Include="src\Utils\AssetManager.h" />
+    <ClInclude Include="src\Utils\Logger.h" />
     <ClInclude Include="src\Utils\Math.h" />
     <ClInclude Include="src\Utils\Shader.h" />
     <ClInclude Include="src\Utils\Sound.h" />
@@ -605,6 +606,7 @@
     <ClCompile Include="src\PhysicsObject.cpp" />
     <ClCompile Include="src\Sprite.cpp" />
     <ClCompile Include="src\Utils\AssetManager.cpp" />
+    <ClCompile Include="src\Utils\Logger.cpp" />
     <ClCompile Include="src\Utils\Shader.cpp" />
     <ClCompile Include="src\Utils\Sound.cpp" />
     <ClCompile Include="src\Utils\StringHelper.cpp" />

--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -1084,6 +1084,9 @@
     <ClInclude Include="src\GameScreen.h" />
     <ClInclude Include="src\GameScreenManager.h" />
     <ClInclude Include="src\GameScreenTest.h" />
+    <ClInclude Include="src\Utils\Logger.h">
+      <Filter>src\Utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ext\DDSTextureLoader.cpp">
@@ -1213,5 +1216,8 @@
     <ClCompile Include="src\GameScreen.cpp" />
     <ClCompile Include="src\GameScreenManager.cpp" />
     <ClCompile Include="src\GameScreenTest.cpp" />
+    <ClCompile Include="src\Utils\Logger.cpp">
+      <Filter>src\Utils</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/Engine/src/Backend/D3D11/D311Context.cpp
+++ b/Engine/src/Backend/D3D11/D311Context.cpp
@@ -33,6 +33,13 @@ namespace Engine
 
 	void D311Context::Init()
 	{
+		Logger::Init(GetStdHandle(STD_OUTPUT_HANDLE)); // Get handel to console (for text coloring)
+		Logger::SetLogLevel(LogStates::LOG_ERR | LogStates::LOG_WARN | LogStates::LOG_MSG);
+		
+		Logger::LogMsg("Logger initalised!", __FILE__);
+
+
+
 		HRESULT hr;
 
 		IDXGIFactory* factory;
@@ -578,7 +585,7 @@ namespace Engine
 		ImGui::NewFrame();
 
 		// Create core dockspace
-		ImGui::SetNextWindowBgAlpha(0);
+		ImGui::SetNextWindowBgAlpha(1);
 		if (mEnableEditor) {
 			ImGui::DockSpaceOverViewport(ImGui::GetMainViewport());
 			ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.180392161f, 0.5450980663f, 0.3411764801f, 1.0f));  // THIS IS BECAUSE THERES TRANSPARENCY ISSUES ATM! NOT PERMANENT
@@ -740,6 +747,10 @@ namespace Engine
 
 		ImGui::Begin("Framerate");
 		ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+		ImGui::End();
+
+		ImGui::Begin("Logger");
+		ImGui::Text("%s", Logger::GetTextBuffer().c_str());
 		ImGui::End();
 
 		ImGui::Render();

--- a/Engine/src/Backend/D3D11/D311Context.cpp
+++ b/Engine/src/Backend/D3D11/D311Context.cpp
@@ -558,7 +558,6 @@ namespace Engine
 		for (ParticleSystem* ps : mParticleSystems)
 			ps->Render();
 
-
 	}
 
 	void D311Context::SwapBuffers()
@@ -621,6 +620,9 @@ namespace Engine
 			{
 				if (ImGui::MenuItem("Toggle Editor Layout")) {
 					mEnableEditor = !mEnableEditor;
+				}
+				if (ImGui::MenuItem("Show logging console")) {
+					mShowLoggingConsole = !mShowLoggingConsole;
 				}
 				ImGui::EndMenu();
 			}
@@ -749,9 +751,23 @@ namespace Engine
 		ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
 		ImGui::End();
 
-		ImGui::Begin("Logger");
-		ImGui::Text("%s", Logger::GetTextBuffer().c_str());
-		ImGui::End();
+		if (mShowLoggingConsole) {
+			ImGui::Begin("Logger");
+
+			std::string sen;
+			for (std::string s : Logger::GetTextBuffer())	// Format the logs into one giant string... not ideal, as we cant do fancy colouring.
+				sen += s;
+			ImGui::Text("%s", sen.c_str());
+
+			if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY())	// Auto scroll to bottom
+				ImGui::SetScrollHereY(1.0f);
+
+			ImGui::End();
+		}
+
+		if (Logger::GetTextBuffer().size() > 512) { // Clear the console once it exceeds 512 logs
+			Logger::GetTextBuffer().erase(Logger::GetTextBuffer().begin(), Logger::GetTextBuffer().begin() + 256); 
+		}
 
 		ImGui::Render();
 		ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());

--- a/Engine/src/Backend/D3D11/D311Context.h
+++ b/Engine/src/Backend/D3D11/D311Context.h
@@ -25,6 +25,8 @@
 #include "ParticalSystem.h"
 #include <Backend/D3D11/D3D11Device.h>
 #include <time.h>
+
+#include "Utils\logger.h"
 //----------------------------------
 
 using namespace DirectX;

--- a/Engine/src/Backend/D3D11/D311Context.h
+++ b/Engine/src/Backend/D3D11/D311Context.h
@@ -86,6 +86,7 @@ namespace Engine
 		TileMap testMap;
 
 		bool mEnableEditor = true; // Very curde, will set up an ImGUi properties struct later - Joe
+		bool mShowLoggingConsole = true;
 
 		// Render to texture for imgui
 		ID3D11Texture2D* mRTTRrenderTargetTexture = nullptr;			// Texture to render to 

--- a/Engine/src/Utils/Logger.cpp
+++ b/Engine/src/Utils/Logger.cpp
@@ -4,7 +4,7 @@ std::bitset<3> Logger::mSet = 7; // Default value of 7 (111 in binary) to enable
 HANDLE Logger::hConsole = NULL;
 time_t Logger::mRawTime;
 struct tm* Logger::mTimeInfo;
-std::string Logger::mTextBuffer = "";
+std::vector<std::string> Logger::mTextBuffer;
 
 void Logger::Init(HANDLE handle)
 {
@@ -25,9 +25,10 @@ void Logger::LogMsg(const char* msg, const char* from) {
 		SetConsoleTextAttribute(hConsole, 10);
 		PrintTime();
 		FormatFrom(from);
-		mTextBuffer += "[MSG]: ";
-		mTextBuffer += msg;
-		mTextBuffer += "\n";
+
+		mTextBuffer.emplace_back("[MSG]: ");
+		mTextBuffer.emplace_back(msg);
+		mTextBuffer.emplace_back("\n");
 		std::cout << "[MSG]: " << msg << std::endl;
 		ResetConsoleColor();
 	}
@@ -39,9 +40,10 @@ void Logger::LogWarn(const char* warnMsg, const char* from) {
 		SetConsoleTextAttribute(hConsole, 14);
 		PrintTime();
 		FormatFrom(from);
-		mTextBuffer += "[WRN]: ";
-		mTextBuffer += warnMsg;
-		mTextBuffer += "\n";
+
+		mTextBuffer.emplace_back("[WRN]: ");
+		mTextBuffer.emplace_back(warnMsg);
+		mTextBuffer.emplace_back("\n");
 		std::cout << "[WRN]: " << warnMsg << std::endl;
 		ResetConsoleColor();
 	}
@@ -53,36 +55,16 @@ void Logger::LogError(const char* errMsg, const char* from) {
 		SetConsoleTextAttribute(hConsole, 12);
 		PrintTime();
 		FormatFrom(from);
-		mTextBuffer += "[ERR]: ";
-		mTextBuffer += errMsg;
-		mTextBuffer += "\n";
+
+		mTextBuffer.emplace_back("[ERR]: ");
+		mTextBuffer.emplace_back(errMsg);
+		mTextBuffer.emplace_back("\n");
 		std::cout << "[ERR]: " << errMsg << std::endl;
 		ResetConsoleColor();
 	}
 }
 
 
-std::string Logger::GetLogMsg(const char* msg) {
-	if (mSet.test(0)) {
-		std::string msg(msg);
-		return "[MSG]: " + msg + "\n";
-	}
-}
-
-std::string Logger::GetLogWarn(const char* warnMsg) {
-	if (mSet.test(1)) {
-		std::string wMsg(warnMsg);
-		return "[WRN]: " + wMsg + "\n";
-
-	}
-}
-
-std::string Logger::GetLogError(const char* errMsg) {
-	if (mSet.test(2)) {
-		std::string eMsg(errMsg);
-		return "[ERR]: " + eMsg + "\n";
-	}
-}
 
 void Logger::PrintTime()
 {
@@ -90,10 +72,10 @@ void Logger::PrintTime()
 	mTimeInfo = localtime(&mRawTime);
 	std::cout << "[" << mTimeInfo->tm_hour << ":" << mTimeInfo->tm_min << ":" << mTimeInfo->tm_sec << "]";
 
-	mTextBuffer += "[" + std::to_string(mTimeInfo->tm_hour);
-	mTextBuffer += ":" + std::to_string(mTimeInfo->tm_min);
-	mTextBuffer += ":" + std::to_string(mTimeInfo->tm_sec);
-	mTextBuffer += "]";
+	mTextBuffer.emplace_back("[" + std::to_string(mTimeInfo->tm_hour));
+	mTextBuffer.emplace_back(":" + std::to_string(mTimeInfo->tm_min));
+	mTextBuffer.emplace_back(":" + std::to_string(mTimeInfo->tm_sec));
+	mTextBuffer.emplace_back("]");
 }
 
 void Logger::FormatFrom(const char* from)
@@ -101,8 +83,8 @@ void Logger::FormatFrom(const char* from)
 	std::string f(from);
 	std::size_t found = f.find_last_of("/\\");
 	if (found != std::string::npos) {
-		mTextBuffer += "[";
-		mTextBuffer += f.substr(found + 1);;
-		mTextBuffer += "]";
+		mTextBuffer.emplace_back("[");
+		mTextBuffer.emplace_back(f.substr(found + 1));
+		mTextBuffer.emplace_back("]");
 	}
 }

--- a/Engine/src/Utils/Logger.cpp
+++ b/Engine/src/Utils/Logger.cpp
@@ -1,0 +1,108 @@
+#include "Logger.h"
+
+std::bitset<3> Logger::mSet = 7; // Default value of 7 (111 in binary) to enable all logs to be displayed.
+HANDLE Logger::hConsole = NULL;
+time_t Logger::mRawTime;
+struct tm* Logger::mTimeInfo;
+std::string Logger::mTextBuffer = "";
+
+void Logger::Init(HANDLE handle)
+{
+	if (handle)
+		hConsole = handle; // Grab handle to console (so we can change colors)
+	else
+		std::cout << "NO HANDLE TO CONSOLE PROVIDED.\nDid you pass in 'GetStdHandle(STD_OUTPUT_HANDLE)'?" << std::endl;
+}
+
+
+void Logger::SetLogLevel(int state) {
+	Logger::mSet = state;
+}
+
+
+void Logger::LogMsg(const char* msg, const char* from) {
+	if (mSet.test(0)) {
+		SetConsoleTextAttribute(hConsole, 10);
+		PrintTime();
+		FormatFrom(from);
+		mTextBuffer += "[MSG]: ";
+		mTextBuffer += msg;
+		mTextBuffer += "\n";
+		std::cout << "[MSG]: " << msg << std::endl;
+		ResetConsoleColor();
+	}
+}
+
+
+void Logger::LogWarn(const char* warnMsg, const char* from) {
+	if (mSet.test(1)) {
+		SetConsoleTextAttribute(hConsole, 14);
+		PrintTime();
+		FormatFrom(from);
+		mTextBuffer += "[WRN]: ";
+		mTextBuffer += warnMsg;
+		mTextBuffer += "\n";
+		std::cout << "[WRN]: " << warnMsg << std::endl;
+		ResetConsoleColor();
+	}
+}
+
+
+void Logger::LogError(const char* errMsg, const char* from) {
+	if (mSet.test(2)) {
+		SetConsoleTextAttribute(hConsole, 12);
+		PrintTime();
+		FormatFrom(from);
+		mTextBuffer += "[ERR]: ";
+		mTextBuffer += errMsg;
+		mTextBuffer += "\n";
+		std::cout << "[ERR]: " << errMsg << std::endl;
+		ResetConsoleColor();
+	}
+}
+
+
+std::string Logger::GetLogMsg(const char* msg) {
+	if (mSet.test(0)) {
+		std::string msg(msg);
+		return "[MSG]: " + msg + "\n";
+	}
+}
+
+std::string Logger::GetLogWarn(const char* warnMsg) {
+	if (mSet.test(1)) {
+		std::string wMsg(warnMsg);
+		return "[WRN]: " + wMsg + "\n";
+
+	}
+}
+
+std::string Logger::GetLogError(const char* errMsg) {
+	if (mSet.test(2)) {
+		std::string eMsg(errMsg);
+		return "[ERR]: " + eMsg + "\n";
+	}
+}
+
+void Logger::PrintTime()
+{
+	time(&mRawTime);
+	mTimeInfo = localtime(&mRawTime);
+	std::cout << "[" << mTimeInfo->tm_hour << ":" << mTimeInfo->tm_min << ":" << mTimeInfo->tm_sec << "]";
+
+	mTextBuffer += "[" + std::to_string(mTimeInfo->tm_hour);
+	mTextBuffer += ":" + std::to_string(mTimeInfo->tm_min);
+	mTextBuffer += ":" + std::to_string(mTimeInfo->tm_sec);
+	mTextBuffer += "]";
+}
+
+void Logger::FormatFrom(const char* from)
+{
+	std::string f(from);
+	std::size_t found = f.find_last_of("/\\");
+	if (found != std::string::npos) {
+		mTextBuffer += "[";
+		mTextBuffer += f.substr(found + 1);;
+		mTextBuffer += "]";
+	}
+}

--- a/Engine/src/Utils/Logger.h
+++ b/Engine/src/Utils/Logger.h
@@ -1,0 +1,153 @@
+#pragma once
+#include <Windows.h>
+#include <iostream>
+#include <Bitset>
+#include <string>
+#include <ctime>
+
+
+enum LogStates {			// Binary:
+	LOG_MSG = 1 << 0,		// 001
+	LOG_WARN = 1 << 1,		// 010
+	LOG_ERR = 1 << 2		// 100
+};
+
+class Logger {
+public:
+
+	static void Init(HANDLE handle); // Takes a handle to the console window
+	static void SetLogLevel(int state);
+
+	// Standard message functions (Green text)
+	static void LogMsg(const char* msg, const char* from="");
+	template<typename T>
+	static void LogMsg(const char* msg, T obj);
+	template<typename T>
+	static void LogMsg(const char* msg, T objs[], size_t size);
+
+	// Warning logging functions (Yellow text)
+	static void LogWarn(const char* warnMsg, const char* from = "");
+	template<typename T>
+	static void LogWarn(const char* warnMsg, T obj);
+	template<typename T>
+	static void LogWarn(const char* warnMsg, T objs[], size_t size);
+
+	// Error logging functions (Red text)
+	static void LogError(const char* errMsg, const char* from = "");
+	template<typename T>
+	static void LogError(const char* errMsg, T obj);
+	template<typename T>
+	static void LogError(const char* errMsg, T objs[], size_t size);
+
+	// Get raw string for custom output
+	static std::string GetLogMsg(const char* msg);
+	static std::string GetLogWarn(const char* warnMsg);
+	static std::string GetLogError(const char* errMsg);
+
+	static std::string& GetTextBuffer() { return mTextBuffer; }
+
+
+private:
+	static std::bitset<3> mSet; // Default value of 7 (111 in binary) to enable all logs to be displayed.
+	static HANDLE hConsole;
+
+	// For getting the time
+	static time_t mRawTime;
+	static struct tm* mTimeInfo;
+
+	static void ResetConsoleColor() { SetConsoleTextAttribute(hConsole, 15); }
+	static void PrintTime();
+	static void FormatFrom(const char* from="");	// Formats the from to not include the abs path
+
+	static std::string mTextBuffer;
+
+	// Deleted as its a purely static class and thus not needed
+	Logger() = delete;
+	~Logger() = delete;
+	Logger(const Logger&) = delete;
+};
+
+
+/*
+	=================================
+	| TEMPLATE IMPLEMENTATION BELOW |
+	=================================
+*/
+template<typename T>
+void Logger::LogMsg(const char* msg, T obj) {
+	if (mSet.test(0)) {
+		SetConsoleTextAttribute(hConsole, 10);
+		std::cout << "[MSG]: " << msg << " | " << "[OBJ]: " << obj << std::endl;
+		ResetConsoleColor();
+	}
+}
+
+template<typename T>
+void Logger::LogMsg(const char* msg, T objs[], size_t size) {
+	if (mSet.test(0)) {
+		SetConsoleTextAttribute(hConsole, 10);
+		std::cout << "[MSG]: " << msg << " | [OBJ_ARR]: {";
+		for (int i = 0; i < size; i++) {
+			if (i != size - 1)
+				std::cout << objs[i] << ", ";
+			else
+				std::cout << objs[i];
+		}
+		std::cout << '}' << std::endl;
+		ResetConsoleColor();
+	}
+}
+
+
+
+template<typename T>
+void Logger::LogWarn(const char* warnMsg, T obj) {
+	if (mSet.test(0)) {
+		SetConsoleTextAttribute(hConsole, 14);
+		std::cout << "[WARN]: " << warnMsg << " | " << "[OBJ]: " << obj << std::endl;
+		ResetConsoleColor();
+	}
+}
+
+template<typename T>
+void Logger::LogWarn(const char* warnMsg, T objs[], size_t size) {
+	if (mSet.test(0)) {
+		SetConsoleTextAttribute(hConsole, 14);
+		std::cout << "[WARN]: " << warnMsg << " | [OBJ_ARR]: { ";
+		for (int i = 0; i < size; i++) {
+			if (i != size - 1)
+				std::cout << objs[i] << ", ";
+			else
+				std::cout << objs[i];
+		}
+		std::cout << " }" << std::endl;
+		ResetConsoleColor();
+	}
+}
+
+
+
+template<typename T>
+void Logger::LogError(const char* errMsg, T obj) {
+	if (mSet.test(0)) {
+		SetConsoleTextAttribute(hConsole, 12);
+		std::cout << "[ERR]: " << errMsg << " | " << "[OBJ]: " << obj << std::endl;
+		ResetConsoleColor();
+	}
+}
+
+template<typename T>
+void Logger::LogError(const char* errMsg, T objs[], size_t size) {
+	if (mSet.test(0)) {
+		SetConsoleTextAttribute(hConsole, 12);
+		std::cout << "[ERR]: " << errMsg << " | [OBJ_ARR]: { ";
+		for (int i = 0; i < size; i++) {
+			if (i != size - 1)
+				std::cout << objs[i] << ", ";
+			else
+				std::cout << objs[i];
+		}
+		std::cout << " }" << std::endl;
+		ResetConsoleColor();
+	}
+}

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -29,6 +29,17 @@ Pos=3,442
 Size=973,233
 Collapsed=0
 
+[Window][Example: Console]
+Pos=60,60
+Size=520,600
+Collapsed=0
+
+[Window][Dear ImGui Demo]
+ViewportPos=695,282
+ViewportId=0xE927CF2F
+Size=550,680
+Collapsed=0
+
 [Docking][Data]
-DockSpace ID=0x8B93E3BD Window=0xA787BDB4 Pos=36,78 Size=1260,658 CentralNode=1 Selected=0x995B0CF8
+DockSpace ID=0x8B93E3BD Window=0xA787BDB4 Pos=192,234 Size=1260,658 CentralNode=1 Selected=0x995B0CF8
 

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -15,8 +15,8 @@ Collapsed=0
 DockId=0x8B93E3BD,0
 
 [Window][Framerate]
-Pos=759,609
-Size=198,48
+Pos=683,394
+Size=283,48
 Collapsed=0
 
 [Window][Scene Hierarchy]
@@ -24,6 +24,11 @@ Pos=977,19
 Size=283,658
 Collapsed=0
 
+[Window][Logger]
+Pos=3,442
+Size=973,233
+Collapsed=0
+
 [Docking][Data]
-DockSpace ID=0x8B93E3BD Window=0xA787BDB4 Pos=88,130 Size=1260,658 CentralNode=1 Selected=0x995B0CF8
+DockSpace ID=0x8B93E3BD Window=0xA787BDB4 Pos=36,78 Size=1260,658 CentralNode=1 Selected=0x995B0CF8
 


### PR DESCRIPTION
## About the logger
The logger has three logging states, those being:
- Message (msg)
- Warning (warn)
- Error (err)

The logger is able to display only text, but can also log basic primitives and arrays.
(floats, std::vectors, bools... ).

## Using the logger
Ensure the logger is #included, it is found under `src/utils/Logger.h`.

To log a simple message:
```cpp
Logger::LogMsg("Hello world!");
Logger::LogWarn("Hello warning!");
Logger::LogError("Hello error!");
```

Optionally you can also state from what file the log msg was called from, this is done by appending the `__FILE__` preprocessor to the end of the function call, like so:
```cpp
Logger::LogMsg("Hello world!", __FILE__);
Logger::LogWarn("Hello warning!", __FILE__);
Logger::LogError("Hello error!", __FILE__);
```

Logging a simple primitive is done like so depending on the severity of the log:
```cpp
/* Syntax: 
Logger::LogXXX(message, primitive, optionalFrom)
*/
float pi = 3.14159f;
Logger::LogMsg("Hello world!", pi,  __FILE__);
Logger::LogWarn("Hello warning!", pi, __FILE__);
Logger::LogError("Hello error!", pi, __FILE__);
```
*Note: The `__FILE__` is always optional, and is added at the very end!*

Logging an array of primitives is done like so:
```cpp
/* Syntax: 
Logger::LogXXX(message, primitive array, elements in array, optionalFrom)
*/
float arr[2];
arr[0] = 3.14f;
arr[1] = 420.69f;
Logger::LogMsg("Hello world!", arr, 2,  __FILE__);
Logger::LogWarn("Hello warning!", arr, 2, __FILE__);
Logger::LogError("Hello error!", arr, 2, __FILE__);

// Logging a std::vector<float>
std::vector<float> vec { 1, 2, 3 };
Logger::LogMsg("Hello world!", &vec[0], vec.size(),  __FILE__);
```
